### PR TITLE
FIX: Add in extension to yml to allow for complete relationship

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -9,3 +9,6 @@ SilverStripe\Subsites\Model\Subsite:
 Heyday\MenuManager\MenuAdmin:
   extensions:
     - SilverStripe\Subsites\Extensions\SubsiteMenuExtension
+Heyday\MenuManager\MenuSet:
+  extensions:
+    - Heyday\MenuManager\Extensions\MenuSubsiteExtension


### PR DESCRIPTION
SS5 upgrade sees an error where the has_one Subsite provided by MenuSubsiteExtension is not present. Just adding that back in to yml.