### PR TITLE
Allow for empty menu title

### DIFF
--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -232,7 +232,7 @@ class MenuItem extends DataObject implements PermissionProvider
     /**
      * @return mixed
      */
-    public function getTitle(): string
+    public function getTitle(): ?string
     {
         return $this->MenuTitle;
     }


### PR DESCRIPTION
Hi,

as the MenuTitle is not a required field, and it is not automatically populated onBeforeWrite, it would be best to allow for a null return value for the getTitle() method, as this currently throws warning notices when building.